### PR TITLE
feat: Produce  GTFS validators reports per release and export it to GCP buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
+  hashes = [
+    "h1:NaDbOqAcA9d8DiAS5/6+5smXwN3/+twJGb3QRiz6pNw=",
+    "zh:0869128d13abe12b297b0cd13b8767f10d6bf047f5afc4215615aabc39c2eb4f",
+    "zh:481ed837d63ba3aa45dd8736da83e911e3509dee0e7961bf5c00ed2644f807b3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9f08fe2977e2166849be24fb9f394e4d2697414d463f7996fd0d7beb4e19a29c",
+    "zh:9fe566deeafd460d27999ca0bbfd85426a5fcfcb40007b23884deb76da127b6f",
+    "zh:a1bd9a60925d9769e0da322e4523330ee86af9dc2e770cba1d0247a999ef29cb",
+    "zh:bb4094c8149f74308b22a87e1ac19bcccca76e8ef021b571074d9bccf1c0c6f0",
+    "zh:c8984c9def239041ce41ec8e19bbd76a49e74ed2024ff736dad60429dee89bcc",
+    "zh:ea4bb5ae73db1de3a586e62f39106f5e56770804a55aa5e6b4f642df973e0e75",
+    "zh:f44a9d596ecc3a8c5653f56ba0cd202ad93b49f76767f4608daf7260b813289e",
+    "zh:f5c5e6cc9f7f070020ab7d95fcc9ed8e20d5cf219978295a71236e22cbb6d508",
+    "zh:fd2273f51dcc8f43403bf1e425ba9db08a57c3ddcba5ad7a51742ccde21ca611",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.67.0"
+  hashes = [
+    "h1:FYSnhl0j80IsT2st63BZAu/cP17W1pEsX1OhLQZ1Muc=",
+    "zh:0cdc7b724f115e9456e6c403c88ba68c36509bb92a717d20db3099b2e6c29968",
+    "zh:0feb6f8c5d9c064bf614cbe1bc1cc46aaf992bc1c8a95212a9d1ddad3da03d0a",
+    "zh:626503789c45350f7caed95fc02e67e505a582539c7fc5a1c6a4f3fb662534fc",
+    "zh:63b1dbc6c223edbdac45cd35e7222c8475d60359d2c1bf50d496f65bc003e3cc",
+    "zh:7b0e4386ae0e53e77ffaba18bdc482111a6aacf8b536cdf255e4bdc0056be91b",
+    "zh:7c48f857071c04efa7afb23bd11752d652ded4cbdf747a5f512dec828fcaba4c",
+    "zh:86c62e8332739d453502f268c3b8eac27454436ec56af2e95642ca18d9bf3502",
+    "zh:8748472a4c15dca832757ed5d9b618950bc0f9c36aadc1556fa2b94cb9c77225",
+    "zh:9c4314e89077e1656a3a54b8ef8648fdb0897b6658570d52dce2a53108829b55",
+    "zh:d506533c2961ae74e65e7908efc34148097470009851352bb77d240375fa628e",
+    "zh:e4068daf384b8ce45e79005d5696271c135546a245cf47554370d0b60c9ac93f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM openjdk:11
+# FROM ghcr.io/mobilitydata/gtfs-validator:4.1.0
+
+# Install dependencies for gsutil
+RUN apt-get update && apt-get install -y \
+    curl \
+    gnupg2 \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gsutil
+RUN curl https://sdk.cloud.google.com | bash
+ENV PATH $PATH:/root/google-cloud-sdk/bin
+
+# Copy the shell script, Java jar file, and any other necessary files
+COPY gtfs-validator-reporter.sh /
+COPY gtfs-validator-reporter-entry.sh /
+# The intended use of gtfs-validator-cli-help.jar is to render the latest command arguments descriptios.
+COPY gtfs-validator-cli-help.jar /
+
+# Set the working directory
+WORKDIR /
+
+# Make the shell script executable
+RUN chmod +x gtfs-validator-reporter.sh
+RUN chmod +x gtfs-validator-reporter-entry.sh
+
+# Define the entry point
+ENTRYPOINT ["./gtfs-validator-reporter-entry.sh"]

--- a/docker/gtfs-validator-reporter-entry.sh
+++ b/docker/gtfs-validator-reporter-entry.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Copyright MobilityData 2023
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##############################################################################################################
+# This scripts invokes gtfs-validator-reporter.sh script with two release versions againts a feed.
+# See also: gtfs-validator-reporter.sh
+##############################################################################################################
+
+
+cloud_storage=""
+report_dir="reports"
+validator_args=()
+release_target_tag=""
+release_reference_tag=""
+working_dir="output"
+
+# Function to display script usage
+usage() {
+  printf "\nScript Usage:\n"
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  -cs, --cloud_storage <path>    Specify the cloud storage path"
+  echo "  -h, --help                     Display this help message"
+  printf "\nGTFS Validator Usage:\n"
+  echo "$(java -jar gtfs-validator-cli-help.jar -h)"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -wd|--working_dir)
+      working_dir="$2"
+      shift # past argument
+      shift # past value
+      ;;      
+    -rr|--release_reference)
+      release_reference_tag="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -rt|--release-target)
+      release_target_tag="$2"
+      shift # past argument
+      shift # past value
+      ;;        
+    -h|--help)
+      usage
+      ;;
+    *) # unknown option
+      validator_args+=("$1") # store in array
+      shift # past argument
+      ;;
+  esac
+done
+
+# Check if release tag is provided
+if [[ -z $release_target_tag || -z $release_reference_tag ]]; then
+  echo "Release tag and release reference are required"
+  usage
+fi
+
+printf "Processing the file with arguments: ${validator_args[@]}"
+
+# Generates the validation reports
+./gtfs-validator-reporter.sh "${validator_args[@]}" -r "${release_reference_tag}"  | tee output.log
+
+./gtfs-validator-reporter.sh "${validator_args[@]}" -r "${release_target_tag}"  | tee output.log
+
+

--- a/docker/gtfs-validator-reporter.sh
+++ b/docker/gtfs-validator-reporter.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Copyright MobilityData 2023
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+######################################################################################################
+# This scripts executes the GTFS validator against a feed.
+# It uses a release tag parameter to download a GTFS validator version.
+# If the cloud_storage parameter is passed, it will upload the report to the GCP cloud_storage address.
+#
+# Usage: 
+# ./gtfs-validator-reporter.sh --url "https://url/gtfs.zip" -cs gs://gtfs-validator-your-storage/ -r 4.1.0
+
+#######################################################################################################
+
+
+cloud_storage=""
+working_dir="output"
+report_dir="report-output"
+validator_args=()
+java_maximum_memory=-Xmx10G
+dataset_id="n/a"
+
+# Function to display script usage
+usage() {
+  printf "\nScript Usage:\n"
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  -cs, --cloud_storage <path>    Specify the cloud storage path"
+  echo "  -h, --help                     Display this help message"
+  printf "\nGTFS Validator Usage:\n"
+  echo "$(java -jar gtfs-validator-cli-help.jar -h)"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -cs|--cloud_storage)
+      cloud_storage="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -did|--dataset_id)
+      dataset_id="$2"
+      shift # past argument
+      shift # past value
+      ;;      
+    -r|--release)
+      release_tag="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -wd|--working_dir)
+      working_dir="$2"
+      shift # past argument
+      shift # past value
+      ;;         
+    -h|--help)
+      usage
+      ;;
+    *) # unknown option
+      validator_args+=("$1") # store in array
+      shift # past argument
+      ;;
+  esac
+done
+
+# Check if release tag is provided
+if [[ -z $release_tag ]]; then
+  echo "Release tag is required"
+  usage
+fi
+
+# Download the Java program from GitHub release
+gtfs_validator=gtfs-validator-$release_tag-cli.jar
+if test -f "$gtfs_validator"; then
+    printf "\n*** $gtfs_validator exists.\n"
+else
+    printf "*** Downloading $gtfs_validator\n"
+    wget --no-check-certificate "https://github.com/MobilityData/gtfs-validator/releases/download/v$release_tag/gtfs-validator-$release_tag-cli.jar" -O "$gtfs_validator"
+fi
+
+
+printf "Processing the file with arguments: $validator_args[*] \n"
+printf "\n"
+
+# clean previous reports
+rm -rf $working_dir/$report_dir-*
+
+# Execute the Java jar file
+java "${java_maximum_memory}" -jar $gtfs_validator "${validator_args[@]}" -o "$working_dir/$report_dir-$release_tag" | tee output.log
+
+# Create summary.json
+# validator_info="{ validator: { "version": "$release_tag", "dataset": "value5"  } }"
+cat "$working_dir/$report_dir-$release_tag/report.json" | jq -c --arg release_tag "$release_tag" --arg dataset_id "$dataset_id" '. + { validator: { "version": $release_tag, "datasetId": $dataset_id } }' > "$working_dir/$report_dir-$release_tag/report-summary.json"
+
+if [[ -n $cloud_storage ]]; then
+  echo "copying to: $cloud_storage/$report_dir-$release_tag"
+  echo "gsutil command: gsutil -m cp -r $working_dir/$report_dir-$release_tag $cloud_storage/$report_dir-$release_tag"
+  # Upload the folder to Google Cloud Storage
+  gsutil -m cp -r "$working_dir/$report_dir-$release_tag" "$cloud_storage/$report_dir-$release_tag"
+else
+  echo "cloud_storage is not set"
+fi
+

--- a/functions/get-gtfs-catalog/main.py
+++ b/functions/get-gtfs-catalog/main.py
@@ -1,0 +1,88 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import pandas as pd
+
+#####################################################################################
+# This GCP function reads the latest dataset versions on the Mobility Database Catalogs.
+# Made for Python 3.9. Requires the modules listed in requirements.txt.
+#####################################################################################
+
+CATALOGS_CSV = "https://storage.googleapis.com/storage/v1/b/mdb-csv/o/sources.csv?alt=media"
+MDB_SOURCE_ID = "mdb_source_id"
+COUNTRY = "location.country_code"
+SUBDIVISION = "location.subdivision_name"
+MUNICIPALITY = "location.municipality"
+PROVIDER = "urls.latest"
+LATEST_URL = "urls.latest"
+
+DATA_TYPE = "data_type"
+GTFS = "gtfs"
+URL_PREFIX = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/"
+URL_SUFFIX = ".zip?alt=media"
+
+EXPORT_FIELDS = [MDB_SOURCE_ID, COUNTRY, SUBDIVISION, MUNICIPALITY, PROVIDER, LATEST_URL]
+
+
+def get_gtfs_datasets():
+    """Reads the GTFS datasets information from  the latest URLs from the Mobility Database catalogs.
+    :return: An array containing a dictionary with the datasets information with the format
+    {
+        "mdb_source_id": 727,
+        "location.country_code": "CA",
+        "location.subdivision_name": "Ontario",
+        "location.municipality": "Toronto",
+        "urls.latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-go-transit-gtfs-727.zip?alt=media"
+        "source_key" : "ca-ontario-go-transit-gtfs-727"
+    }
+    """
+    catalogs = pd.read_csv(CATALOGS_CSV)
+    result = []
+    catalogs_gtfs = catalogs[catalogs[DATA_TYPE] == GTFS]
+    for index, dataset in catalogs_gtfs.iterrows():
+        item = {
+            "source_key": dataset[LATEST_URL].replace(URL_PREFIX, "").replace(URL_SUFFIX, "")
+            if dataset[LATEST_URL] == dataset[LATEST_URL] else
+            dataset[MDB_SOURCE_ID]
+        }
+        for field in EXPORT_FIELDS:
+            item[field] = dataset[field] if dataset[field] == dataset[field] else ""
+        result.append(item)
+    return result
+
+
+def get_request(request):
+    """Cloud function to read the GTFS datasets information from  the latest URLs from the Mobility Database catalogs.
+    Args:
+        request (flask.Request): HTTP request object.
+    Returns:
+    {
+        "mdb_source_id": 727,
+        "location.country_code": "CA",
+        "location.subdivision_name": "Ontario",
+        "location.municipality": "Toronto",
+        "urls.latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-go-transit-gtfs-727.zip?alt=media"
+    }
+    """
+    result = get_gtfs_datasets()
+    print("Returning datasets count=" + str(len(result)))
+    headers = {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json'
+    }
+    return json.dumps(result), 200, headers
+    # return json.dumps(result)
+
+
+if __name__ == '__main__':
+    print(get_request({}))

--- a/functions/get-gtfs-catalog/requirements.txt
+++ b/functions/get-gtfs-catalog/requirements.txt
@@ -1,0 +1,16 @@
+cachetools==4.2.2
+certifi==2022.12.7
+charset-normalizer==2.0.4
+idna==3.2
+pandas==1.4.3
+packaging==21.0
+protobuf==3.18.3
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+pyparsing==2.4.7
+python-dateutil==2.8.1
+pytz==2021.1
+requests==2.26.0
+rsa==4.7.2
+six==1.16.0
+urllib3==1.26.6

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,174 @@
+/**
+ * MobilityData 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  project = var.project_id
+  region =  var.gcp_region
+}
+
+resource "google_project_service" "workflows" {
+  service            = "workflows.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "containers_service_account" {
+  account_id   = "containers-sa"
+  display_name = "Containers Service Account"
+}
+
+resource "google_project_iam_member" "log_binding" {
+  project = var.project_id
+  role    = "roles/logging.logWriter" #logging.logEntries.create
+  member  = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+resource "google_project_iam_member" "run_admin_binding" {
+  project = var.project_id
+  role    = "roles/run.admin" #run.jobs.create
+  member  = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+resource "google_project_iam_member" "service_user_binding" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser" #iam.serviceAccounts.actAs
+  member  = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+resource "google_storage_bucket" "mobilitydata-gtfs-validation-results" {
+  name          = "mobilitydata-gtfs-validation-results"
+  location      = "US"
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+}
+
+resource "google_storage_bucket_iam_member" "bucket_member" {
+  bucket = google_storage_bucket.mobilitydata-gtfs-validation-results.name
+  role   = "roles/storage.objectAdmin"
+
+  member = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+resource "google_artifact_registry_repository" "gtfs-validator-registry" {
+  location      = "us-central1"
+  repository_id = "gtfs-validator-registry"
+  description   = "GTFS Validator Docker Registry"
+  format        = "DOCKER"
+
+  docker_config {
+    immutable_tags = true
+  }
+}
+
+resource "google_workflows_workflow" "workflow-gtfs-validator" {
+  name            = "workflow-gtfs-validator"
+  region          = var.gcp_region
+  description     = "GTFS Validator Workflow"
+  service_account = google_service_account.containers_service_account.id
+  source_contents = file("./workflow-gtfs-validator.yaml")
+  depends_on      = [google_project_service.workflows]
+}
+
+resource "google_storage_bucket" "functionBucket" {
+  name     = "${var.project_id}-function"
+  location = var.gcp_region
+}
+
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = "./functions/get-gtfs-catalog"
+  output_path = "./tmp/get-gtfs-catalog.zip"
+}
+
+# Add source code zip to the Cloud Function's bucket
+resource "google_storage_bucket_object" "archive" {
+  source       = data.archive_file.source.output_path
+  content_type = "application/zip"
+
+  # Append to the MD5 checksum of the files's content
+  # to force the zip to be updated as soon as a change occurs
+  name   = "src-${data.archive_file.source.output_md5}.zip"
+  bucket = google_storage_bucket.functionBucket.name
+
+  # Dependencies are automatically inferred so these lines can be deleted
+  depends_on = [
+    google_storage_bucket.functionBucket, # declared in `storage.tf`
+    data.archive_file.source
+  ]
+}
+
+resource "google_cloudfunctions_function" "getGtfsCatalogFunction" {
+  name        = "get-gtfs-catalog"
+  description = "get-gtfs-catalog"
+  runtime     = "python39"
+
+  available_memory_mb   = 256
+  source_archive_bucket = google_storage_bucket.functionBucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  trigger_http          = true
+  entry_point           = "get_request"
+
+  https_trigger_security_level = "SECURE_ALWAYS"
+  timeout                      = 120
+  labels = {
+    group = "gtfs-validator-metrics"
+  }
+
+}
+
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  project        = google_cloudfunctions_function.getGtfsCatalogFunction.project
+  region         = google_cloudfunctions_function.getGtfsCatalogFunction.region
+  cloud_function = google_cloudfunctions_function.getGtfsCatalogFunction.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member  = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+resource "google_workflows_workflow" "workflow-gtfs-catalog-validator" {
+  name            = "workflow-gtfs-catalog-validator"
+  region          = var.gcp_region
+  description     = "GTFS Catalog Validator Workflow"
+  service_account = google_service_account.containers_service_account.id
+  source_contents = templatefile("./workflow-gtfs-catalog-validator.yaml", { "configCatalogFunctionUrl" = "${google_cloudfunctions_function.getGtfsCatalogFunction.https_trigger_url}"})
+  depends_on = [google_project_service.workflows, google_cloudfunctions_function.getGtfsCatalogFunction]
+}
+
+resource "google_project_iam_member" "workflow_executor_binding" {
+  project = var.project_id
+  role    = "roles/workflows.invoker" #workflows.executions.create
+  member  = "serviceAccount:${google_service_account.containers_service_account.email}"
+}
+
+## Big Query
+
+resource "google_bigquery_dataset" "gtfs-results-dataset" {
+  dataset_id                  = var.gtfs_results_dataset_id
+  friendly_name               = "gtfs_results"
+  description                 = "GTFS Validation Results Dataset"
+  location                    = var.gtfs_results_dataset_location
+  #default_table_expiration_ms = 3600000
+}
+
+resource "google_bigquery_table" "validation_results_table" {
+  dataset_id = var.gtfs_results_dataset_id
+  table_id = var.gtfs_results_dataset_table_id
+
+   schema = "${file("./validation-result-schema.json")}"
+
+   depends_on = [ google_bigquery_dataset.gtfs-results-dataset ]
+}

--- a/scripts/convert-to-ndjson.sh
+++ b/scripts/convert-to-ndjson.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Copyright MobilityData 2023
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+######################################################################################################
+# This scripts converts JSON all files with the specified name within a path of a GCP bucket to NDJSON (New Line delimiter JSON).
+#
+# Usage: 
+# ./convert-to-ndjson.sh -bp my-bucket/reports -f report.json
+#######################################################################################################
+
+bucket_path=""
+filename=""
+concurrency_limit=10
+
+# Function to display script usage
+usage() {
+  printf "\nScript Usage:\n"
+  echo "Usage: $0 [options]"
+  echo "Options:"
+  echo "  -bp, --bucket_path <path>    Specify the GCP cloud storage bucket. Example: my-bucket/reports"
+  echo "  -f, --filename <path>    Specify the filename to match with the search and convert"
+  echo "  -h, --help                     Display this help message"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -bp|--bucket_path)
+      bucket_path="$2"
+      shift # past argument
+      shift # past value
+      ;;      
+    -f|--filename)
+      filename="$2"
+      shift # past argument
+      shift # past value
+      ;;     
+    -h|--help)
+      usage
+      ;;
+    *) # unknown option
+      shift # past argument
+      ;;
+  esac
+done
+
+temp_dir=$(mktemp -d)
+
+echo "Listing files gs://$bucket_path/ "
+
+# List all summary-report.json files in the bucket and their paths
+files=$(gsutil ls -r gs://$bucket_path/ | grep "/$filename$")
+
+file_count=$(echo "$files" | wc -l)
+echo "Number of files found: $file_count"
+
+if [[ -z "$files" ]]; then
+  echo "No files found."
+  exit 1
+fi
+
+while IFS= read -r file; do
+  (
+    original_filename=$(basename "$file")
+
+  relative_path=${file#gs://$bucket_path/}
+  relative_path=${relative_path%"$original_filename"}
+  echo "Relative path $relative_path"
+
+  local_directory="$temp_dir/$relative_path"
+  mkdir -p "$local_directory"
+
+  echo "Original filename $original_filename"
+  output_filename="${original_filename%.json}-nd.json"
+  
+  # Convert the file to NDJSON using jq and save it to the output file
+  echo "Converting $local_directory/$output_filename"
+  gsutil cp "$file" "$local_directory/$original_filename"
+  echo "Copied $local_directory/$original_filename"
+  jq -c '.' "$local_directory/$original_filename" > "$local_directory/$output_filename.tmp"
+  mv "$local_directory/$output_filename.tmp" "$local_directory/$output_filename"
+
+  echo "Uploading $local_directory/$output_filename to gs://$bucket_path/$relative_path/"
+  gsutil cp "$local_directory/$output_filename" "gs://$bucket_path/$relative_path/"
+  ) &
+
+  # allow to execute up to $N jobs in parallel
+  if [[ $(jobs -r -p | wc -l) -ge $concurrency_limit ]]; then
+      wait
+  fi
+done <<< "$files"
+
+# no more jobs to be started but wait for pending jobs to complete
+wait
+
+rm -r "$temp_dir"

--- a/validation-result-schema.json
+++ b/validation-result-schema.json
@@ -1,0 +1,92 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "validator",
+    "type": "RECORD",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "version",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "datasetId",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "name": "notices",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "code",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "severity",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "totalNotices",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
+      }
+    ]
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "systemErrors",
+    "type": "RECORD",
+    "fields": [
+      {
+        "name": "notices",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "fields": [
+          {
+            "name": "code",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "severity",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "totalNotices",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "sampleNotices",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+              {
+                "name": "exception",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "message",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              },
+              {
+                "name": "validator",
+                "type": "STRING",
+                "mode": "NULLABLE"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type = string
+  description = "GCP project ID"
+}
+
+variable "gcp_region" {
+  type = string
+  description = "GCP region"
+}
+
+variable "gtfs_results_dataset_id" {
+  type = string
+  description = "GTFS BigQuery table Id"
+  default = "gtfs_results_dataset"
+}
+
+variable "gtfs_results_dataset_location" {
+  type = string
+  description = "GTFS BigQuery table location"
+  default = "US"
+}
+
+variable "gtfs_results_dataset_table_id" {
+  type = string
+  description = "GTFS BigQuery table location"
+  default = "gtfs_results"
+}

--- a/workflow-gtfs-catalog-validator.yaml
+++ b/workflow-gtfs-catalog-validator.yaml
@@ -1,0 +1,148 @@
+#
+# Validates a GTFS dataset executing the GTFS validator on Cloud Run.
+#
+## Input:
+#  {
+#    "results_bucket_path": "gs://gtfs-validator-results-playground/reports",
+#    "concurrency_limits": 20
+#  }
+## Output:
+# No output
+
+main:
+  params: [args]
+  steps:
+    - validate:
+        try:
+            steps:
+            - init:
+                assign:
+                # example: gs://gtfs-validator-results-playground/reports
+                - resultsBucketPath: $${args.results_bucket_path}
+                # Extrating the bucket's name from the bucket's path 
+                #  example: gtfs-validator-results-playground
+                - resultsBucketName: $${text.replace_all(resultsBucketPath, "gs://","")}
+                - resultsBucketName: $${text.split(resultsBucketName, "/")[0]}
+                #  Path refix included in the resultsBucketPath
+                # example: reports
+                - resultsBucketPrefixPath: $${text.substring(resultsBucketPath, len("gs://") + len(resultsBucketName) + 1, len(resultsBucketPath))}
+                - catalogUrl: ${configCatalogFunctionUrl}
+                - validateWorkflow: "workflow-gtfs-validator"
+                - location: $${default(map.get(args, "region"), "us-central1")}
+                - concurrencyLimits: $${default(map.get(args, "concurrency_limits"), 20)}
+                - dateTime: $${text.substring(time.format(sys.now()), 0, 16)}
+                - reportsExportPath: $${dateTime + "/" + sys.get_env("GOOGLE_CLOUD_WORKFLOW_EXECUTION_ID")}
+                - totalSucceeded: 0
+                - totalFailed: 0
+                - failedDatasets: []
+            - initLog:
+                call: sys.log
+                args:
+                    text: $${"Validating catalog from " + catalogUrl + ". Reports added to " + reportsExportPath }
+                    severity: INFO
+            - retrieveCatalog:
+                call: http.get
+                args:
+                    url: $${catalogUrl}
+                    auth:
+                        type: OIDC                       
+                result: catalogResponse
+            - datasetResponseLog:
+                call: sys.log
+                args:
+                    text: $${"Loaded catalog database with " + len(catalogResponse.body) + " datasets"}
+                    severity: INFO
+            - datasetCounter:
+                assign:
+                    - datasetCount: $${len(catalogResponse.body)}
+            - validationLoop:
+                parallel:
+                  concurrency_limit: $${concurrencyLimits}
+                  shared: [totalSucceeded, totalFailed, failedDatasets]
+                  for:
+                      value: datasetIndex
+                      range: [0, $${len(catalogResponse.body) -1}] # inclusive beginning and ending values
+                      steps:
+                          - datasetVars:
+                              assign:
+                              - validatorImage: "us-central1-docker.pkg.dev/md-poc-playground/gtfs-validator-registry/gtfs-validator-reporter@sha256:e40484c4326aa40af7958dc120c5b314931a689cc0bb93bac42337d363c2772e" 
+                              - feedUrl: $${catalogResponse.body[datasetIndex]["urls.latest"]}
+                              - feedId: $${catalogResponse.body[datasetIndex]["mdb_source_id"]}
+                              - feedKey: $${catalogResponse.body[datasetIndex]["source_key"]}
+                              - reference_validator_version: "4.0.0"
+                              - target_validator_version: "4.1.0"
+                              - reportFilename: $${ resultsBucketPath + "/" + reportsExportPath + "/" + feedKey + ".json"}
+                          - datasetLog:
+                              call: sys.log
+                              args:
+                                  text: $${"Validating dataset " + feedKey }
+                                  severity: INFO
+                          - callValidateWorkflow:
+                              try:
+                                steps:
+                                    - callValidate:
+                                        call: googleapis.workflowexecutions.v1beta.projects.locations.workflows.executions.run
+                                        args:
+                                          workflow_id: $${validateWorkflow}
+                                          location: $${location}
+                                          project_id: $${sys.get_env("GOOGLE_CLOUD_PROJECT_ID")}
+                                          argument:
+                                              validator_image: $${validatorImage}
+                                              feed_url: $${feedUrl}
+                                              feed_id: $${feedId}
+                                              feed_key: $${feedKey}
+                                              reports_bucket_path: $${resultsBucketPath + "/" + reportsExportPath + "/" + feedKey}
+                                              reference_validator_version: $${reference_validator_version}
+                                              target_validator_version: $${target_validator_version}
+                                        result: validateDatasetResponse
+                                    - validateDatasetResponseLog:
+                                        call: sys.log
+                                        args:
+                                            text: $${"Dataset validation response " + json.encode_to_string(validateDatasetResponse)}
+                                            severity: INFO
+                                    - summarySucceeded:
+                                        assign:
+                                        - totalSucceeded: $${totalSucceeded + 1}                                                
+
+                              except:
+                                  as: e
+                                  steps:
+                                      - summaryFailed:
+                                          assign:
+                                          - totalFailed: $${totalFailed + 1} 
+                                      - logException:
+                                          call: sys.log
+                                          args:
+                                              text: $${"Error validating dataset " + feedId + " exception " + json.encode_to_string(e)}
+                                              severity: ERROR
+                                      - addErrorValidation:
+                                          assign:
+                                          - failedDatasets[len(failedDatasets) - 1]: feedId                                   
+
+        except:
+            as: e
+            steps:
+                - unhandled_exception:
+                    raise: $${e}
+    - persistSummary:      
+        call: googleapis.storage.v1.objects.insert
+        args:
+          bucket: $${resultsBucketName}
+          uploadType: "media"
+          name: $${resultsBucketPrefixPath + "/" + reportsExportPath + "/" + "summary.json"}
+          body:
+            succeeded: $${totalSucceeded}
+            failed: $${totalFailed}
+            failedDatasets: $${failedDatasets}
+            total: $${totalSucceeded + totalFailed}
+            concurrencyLimits: $${concurrencyLimits}
+            resultsBucketPath: $${resultsBucketPath}
+    - return:
+        return:
+            summary:
+                succeeded: $${totalSucceeded}
+                failed: $${totalFailed}
+                failedDatasets: $${failedDatasets}
+                total: $${totalSucceeded + totalFailed}
+                concurrencyLimits: $${concurrencyLimits}
+                resultsBucketPath: $${resultsBucketPath}

--- a/workflow-gtfs-validator.yaml
+++ b/workflow-gtfs-validator.yaml
@@ -1,0 +1,113 @@
+#
+# Validates a GTFS dataset executing the GTFS validator on Cloud Run.
+#
+## Input:
+#  {
+#    "validator_image": "us-central1-docker.pkg.dev/md-poc-playground/gtfs-validator-registry/gtfs-validator-reporter@sha256:26767d681e5405e0e20a755d88047f126af6c3aebe46d898091f2e7c5c82bdd1",
+#    "feed_url": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.zip?alt=media",
+#    "feed_id": "1234",
+#    "feed_key": "ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6",
+#    "reference_validator_version": "4.0.0",
+#    "target_validator_version": "4.1.0",
+#    "reports_bucket_path": "gs://gtfs-validator-results-playground/reports"
+#  }
+## Output:
+# No output
+
+main:
+    params: [args]
+    steps:
+        - init:
+            assign:
+            - reportsBucketPath: ${args.reports_bucket_path}
+            - feedUrl: ${args.feed_url}
+            - feedKey: ${args.feed_key}
+            - location: ${default(map.get(args, "region"), "us-central1")}
+            - dateTime: ${text.replace_all("" + sys.now(), ".", "")}
+            - feedId: ${args.feed_id}
+            - validatorImage: ${args.validator_image}
+            - referenceValidatorVersion: ${args.reference_validator_version}
+            - targetValidatorVersion: ${args.target_validator_version}
+            - jobName: ${"gtfs-" + dateTime + "-" + text.replace_all(feedKey, "-", "")}
+            - jobName: ${text.substring(jobName, 0, if(len(jobName) > 63, 63, len(jobName) ) )}
+        - initLog:
+            call: sys.log
+            args:
+              text: ${"Creating Job " + jobName}
+              severity: INFO
+        - createCloudRunJob:
+            call: googleapis.run.v1.namespaces.jobs.create
+            args:
+                location: "${location}"
+                parent: ${"namespaces/" + sys.get_env("GOOGLE_CLOUD_PROJECT_NUMBER")}
+                body:
+                    apiVersion: run.googleapis.com/v1
+                    kind: Job
+                    metadata:
+                        name: ${jobName}
+                    spec:
+                        template:
+                            metadata:
+                                annotations:
+                                    run.googleapis.com/client-name: cloud-console
+                                    client.knative.dev/user-image: ${validatorImage}
+                                    run.googleapis.com/execution-environment: gen2                            
+                            spec:
+                                parallelism: 1
+                                taskCount: 1
+                                template:
+                                    spec:
+                                        containers:
+                                        - image: ${validatorImage}
+                                          args:
+                                            - --url
+                                            - ${feedUrl}
+                                            - -cs
+                                            - ${reportsBucketPath}
+                                            - -rr
+                                            - ${referenceValidatorVersion}
+                                            - -rt
+                                            - ${targetValidatorVersion}
+                                            - -did
+                                            - ${feedKey}
+                                          resources:
+                                            limits:
+                                                cpu: 1000m
+                                                memory: 1Gi
+                                        maxRetries: 3
+                                        timeoutSeconds: '600'
+                                        serviceAccountName: containers-sa@md-poc-playground.iam.gserviceaccount.com
+
+            result: createJobResult
+        - createJobLog:
+            call: sys.log
+            args:
+              text: ${json.encode_to_string(createJobResult)}
+              severity: INFO
+        - executeJob:
+            call: googleapis.run.v1.namespaces.jobs.run
+            args:
+                location: ${location}
+                name: ${"namespaces/" + sys.get_env("GOOGLE_CLOUD_PROJECT_NUMBER") + "/jobs/" + jobName}
+            result: executionResult
+        - executionJobLog:
+            call: sys.log
+            args:
+                text: ${executionResult}
+        - deleteCloudRunJob:
+            call: googleapis.run.v1.namespaces.jobs.delete
+            args:
+                location: ${location}
+                name: ${"namespaces/" + sys.get_env("GOOGLE_CLOUD_PROJECT_NUMBER") + "/jobs/" + jobName}
+            result: deleteJobResult
+        - deleteJobLog:
+            call: sys.log
+            args:
+                text: ${deleteJobResult}            
+        - response:
+            return:
+                executionResult: ${executionResult}
+                feedId: ${feedId}
+                feedKey: ${feedKey}
+                dateTime: ${dateTime}
+


### PR DESCRIPTION
# Description

This PR adds the following resources.
- GCP function to retrieve all the Mobility Data Catalogs
- GCP workflows to execute Cloud Run instance that validates and exports the reports to a GCP bucket
- Docker container to support GTFS validator execution per version
- Terraform scripts 

WIP(Remove when PR is Ready)
- [ ] Update README.md 
- [ ] Review and update all scripts and files documentation